### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.5
+
+# Where manga will be downloader
+VOLUME /data
+
+# Install app
+WORKDIR /usr/src/app
+COPY . .
+RUN pip install -q -r requirements.txt && \
+    python setup.py -q install
+
+# Switch back to /data directory
+WORKDIR /data
+
+# Define manga-py as entrypoint
+ENTRYPOINT ["manga-py"]

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,29 @@ Installation
 
     manga-py http://manga.url/manga/name  # For download manga
 
+Installation using docker
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1) Have docker installed and running
+2) Clone this repository:
+
+.. code:: bash
+
+    git clone https://github.com/yuru-yuri/manga-dl.git
+    cd manga-dl
+
+3) Build:
+
+.. code:: bash
+
+    docker build -t manga-py .
+
+4) Run program:
+
+.. code:: bash
+
+    docker run -v /full/path/to/manga_root_dir:/data manga-py http://manga.url/manga/name
+
 Installation on the Android
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 See https://github.com/yuru-yuri/manga-dl/issues/48


### PR DESCRIPTION
Hello,

This is a simple Dockerfile as you were probably aiming for this in #64.
You might want to create a docker hub account and tie it to your github account to take advantage of automated build. Doing so will allow your user to simply pull the resulting image.

Bellow is an example of the resulting image

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
python              3.5                 7f4efc85a56c        7 days ago          920MB
$ docker build -t manga-py .
Sending build context to Docker daemon  21.91MB
Step 1/7 : FROM python:3.5
 ---> 7f4efc85a56c
Step 2/7 : VOLUME /data
 ---> Running in 7a030b391ec5
Removing intermediate container 7a030b391ec5
 ---> c87eec64778d
Step 3/7 : WORKDIR /usr/src/app
 ---> Running in 7db4ed5e5d82
Removing intermediate container 7db4ed5e5d82
 ---> cbe6bfd28f12
Step 4/7 : COPY . .
 ---> d5e865dacb86
Step 5/7 : RUN pip install -q -r requirements.txt &&     python setup.py -q install
 ---> Running in 242899286bc3
Removing intermediate container 242899286bc3
 ---> b78a2feb2a44
Step 6/7 : WORKDIR /data
 ---> Running in 015cf0a7df4b
Removing intermediate container 015cf0a7df4b
 ---> 873c95e92b64
Step 7/7 : ENTRYPOINT ["manga-py"]
 ---> Running in b5365d100560
Removing intermediate container b5365d100560
 ---> e413a5054e63
Successfully built e413a5054e63
Successfully tagged manga-py:latest
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
manga-py            latest              e413a5054e63        25 seconds ago      1.06GB
python              3.5                 7f4efc85a56c        7 days ago          920MB
$ docker run -v $HOME:/data manga-py -h
usage: manga-py [--version] [-n name] [-d path] [-np]
                [--not-change-files-extension] [--no-webp] [--cbz]
                [--rename-pages] [-s count] [-c count]
                [--user-agent USER_AGENT] [--proxy PROXY]
                [--reverse-downloading] [--rewrite-exists-archives] [-nm]
                [--one-thread] [--zero-fill] [-N] [--min-free-space Mb] [-h]
                [--print-json] [--simulate]
                url
--8<--
docker run -v $HOME:/data manga-py -N --cbz https://www.mangareader.net/hunter-x-hunter
100% (33 of 33) |########################| Elapsed Time: 0:00:07 Time:  0:00:07
100% (24 of 24) |########################| Elapsed Time: 0:00:05 Time:  0:00:05
 90% (18 of 20) |#####################   | Elapsed Time: 0:00:01 ETA:   0:00:00
--8<--
```

As you can see the image itself is 1GB, but you can always start from a slimer base image (there is slim and alpine which can do the trick). You can also integrate node.js.

Cheers.
W.