### PR TITLE
Removed size specifier to get original jpg files [comic.webnewtype.com]

### DIFF
--- a/manga_py/providers/comic_webnewtype_com.py
+++ b/manga_py/providers/comic_webnewtype_com.py
@@ -20,7 +20,9 @@ class ComicWebNewTypeCom(Provider, Std):
     def get_files(self):
         url = self.chapter
         items = self.http_get(url + 'json/', headers={'x-requested-with': 'XMLHttpRequest'})
-        return self.json.loads(items)
+        imgs = self.json.loads(items)
+        imgs = [self.re.sub(r'jpg.+', 'jpg', img) for img in imgs]
+        return imgs
 
     def get_cover(self) -> str:
         return self._cover_from_content('.WorkSummary-content img')


### PR DESCRIPTION
Hi,
Removed trailing "/w800q75nc/" from the image urls in JSON for comic.webnewtype.com.

/rsz/C1/img/comic/engawa/engawa_28_02-e4028ecc-b5cd-45d8-8c83-e46241bb99fd.jpg/w800q75nc/
/rsz/C1/img/comic/engawa/engawa_28_02-e4028ecc-b5cd-45d8-8c83-e46241bb99fd.jpg

I think it's useful for some manga viewers which cannot read image files without extensions.

Thanks!