### PR TITLE
Add packages to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,14 @@ REQUIREMENTS = [
     'Pillow',
     'requests',
     'pycrypto',
-    'cfscrape',
+    'cloudscraper',
     'progressbar2',
     'urllib3',
     'packaging',
     'pyexecjs>=1.5.1',
     'html-purifier',
+    'selenium',
+    'loguru',
 ]
 
 


### PR DESCRIPTION
Fix `cloudscraper` missing from the update found two more libraries missing.

In `requirements.txt` found that seems not needed (deleting this is at your discretion):
* `numpy`
* `pycryptodome`